### PR TITLE
ci: 限制文档部署工作流仅在上游主仓库运行

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,6 +22,7 @@ jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
+    if: github.repository == 'jeanhua/AniaBot'
 
     steps:
       - name: Checkout main branch


### PR DESCRIPTION
### 动机与背景
`.github/workflows/docs.yaml` 在 `main` 分支有 push 时会自动触发构建与 GitHub Pages 部署。
由于下游 Fork 仓库默认没有配置 GitHub Pages 环境与发布权限，导致 Fork 用户在同步主分支代码时会收到 CI 构建失败（Failed）报错邮件。

### 改动内容
在 `build` job 中增加 `if: github.repository == 'jeanhua/AniaBot'` 限制，确保该工作流仅在官方主仓库运行，避免下游 Fork 仓库误触发。