### PR TITLE
fix(aichat): 过滤 SSE 注释帧与无效空行，修复部分网关流式返回 unexpected end of JSON input 问题

### DIFF
--- a/bot/component/aichat/llmbackend_chatcompletions.go
+++ b/bot/component/aichat/llmbackend_chatcompletions.go
@@ -28,6 +28,8 @@ func newChatCompletionsBackend(baseURL, apiKey, model string) *chatCompletionsBa
 			option.WithBaseURL(baseURL),
 			// 覆盖 SDK 默认 UA，标识请求来源与版本
 			option.WithHeader("User-Agent", version.UserAgent()),
+			// 过滤 SSE 注释帧，防止 OpenRouter 等网关的注释行导致 unexpected end of JSON input
+			option.WithHTTPClient(newOpenAIHTTPClient()),
 		),
 		model: model,
 	}

--- a/bot/component/aichat/llmbackend_responses.go
+++ b/bot/component/aichat/llmbackend_responses.go
@@ -31,6 +31,8 @@ func newResponsesBackend(baseURL, apiKey, model string) *responsesBackend {
 			option.WithBaseURL(baseURL),
 			// 覆盖 SDK 默认 UA，标识请求来源与版本
 			option.WithHeader("User-Agent", version.UserAgent()),
+			// 过滤 SSE 注释帧，防止 OpenRouter 等网关的注释行导致 unexpected end of JSON input
+			option.WithHTTPClient(newOpenAIHTTPClient()),
 		),
 		model: model,
 	}

--- a/bot/component/aichat/sse_transport.go
+++ b/bot/component/aichat/sse_transport.go
@@ -1,0 +1,97 @@
+package aichat
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+)
+
+// sseCommentFilterReader 过滤 SSE 响应流中的注释行与无效空行。
+//
+// 背景：部分网关或中转服务（如 OpenRouter 在等待上游模型就绪时）会发送形如
+// ": OPENROUTER PROCESSING\n\n" 或 ": keep-alive\n\n" 的 SSE 注释帧。
+// openai-go SDK 内置的 ssestream.Decoder 在解析空行 "\n\n" 时，因没有
+// data 字段而产生 Data 为空的 Event，随后传给 json.Unmarshal 导致
+// "unexpected end of JSON input" 错误。
+//
+// 本 Reader 在 HTTP 传输层剔除所有以 ':' 开头的注释行，并丢弃未跟随在有效
+// "data:" 行之后的孤立空行，确保传递给 SDK 的只有完整的 SSE 事件。
+type sseCommentFilterReader struct {
+	reader  *bufio.Reader
+	buf     bytes.Buffer
+	hasData bool
+}
+
+func newSSECommentFilterReader(r io.Reader) *sseCommentFilterReader {
+	return &sseCommentFilterReader{reader: bufio.NewReader(r)}
+}
+
+func (f *sseCommentFilterReader) Read(p []byte) (int, error) {
+	for f.buf.Len() == 0 {
+		line, err := f.reader.ReadSlice('\n')
+		if len(line) > 0 {
+			trimmed := bytes.TrimSpace(line)
+			if len(trimmed) == 0 {
+				// 空行：仅在之前存在有效 data: 字段（构成合法 SSE 事件块）时向下传递，
+				// 否则（如注释块后的空行、纯心跳空行）直接丢弃，防止 SDK 产生空事件报错
+				if f.hasData {
+					f.buf.Write(line)
+					f.hasData = false
+				}
+			} else if trimmed[0] == ':' {
+				// 注释行直接丢弃
+			} else {
+				if bytes.HasPrefix(trimmed, []byte("data:")) {
+					f.hasData = true
+				}
+				f.buf.Write(line)
+			}
+		}
+		if err != nil {
+			if f.buf.Len() > 0 {
+				break
+			}
+			return 0, err
+		}
+	}
+	return f.buf.Read(p)
+}
+
+type sseFilterBody struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (b *sseFilterBody) Close() error {
+	return b.closer.Close()
+}
+
+// sseTransport 拦截 text/event-stream 响应并包装 Body 进行 SSE 过滤
+type sseTransport struct {
+	base http.RoundTripper
+}
+
+func (t *sseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	ct := resp.Header.Get("Content-Type")
+	if bytes.Contains([]byte(ct), []byte("text/event-stream")) && resp.Body != nil {
+		resp.Body = &sseFilterBody{
+			Reader: newSSECommentFilterReader(resp.Body),
+			closer: resp.Body,
+		}
+	}
+	return resp, nil
+}
+
+// newOpenAIHTTPClient 返回内置 SSE 兼容过滤器的 http.Client，使用 http.DefaultTransport
+// 作为底层传输，完整保留环境变量代理（HTTP_PROXY/HTTPS_PROXY）与 HTTP/2 支持。
+func newOpenAIHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &sseTransport{base: http.DefaultTransport},
+	}
+}
+

--- a/bot/component/aichat/sse_transport_test.go
+++ b/bot/component/aichat/sse_transport_test.go
@@ -1,0 +1,77 @@
+package aichat
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSSECommentFilterReader(t *testing.T) {
+	input := ": OPENROUTER PROCESSING\n\n" +
+		": keep-alive\n\n" +
+		"\n\n" +
+		"data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n" +
+		": middle comment\n\n" +
+		"data: {\"id\":\"2\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	reader := newSSECommentFilterReader(strings.NewReader(input))
+	gotBytes, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	got := string(gotBytes)
+
+	want := "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n" +
+		"data: {\"id\":\"2\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	if got != want {
+		t.Fatalf("output mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestSSECommentFilterReaderMultiLineData(t *testing.T) {
+	input := ": comment\n\n" +
+		"data: line1\n" +
+		"data: line2\n\n"
+
+	reader := newSSECommentFilterReader(strings.NewReader(input))
+	gotBytes, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	got := string(gotBytes)
+
+	want := "data: line1\n" +
+		"data: line2\n\n"
+
+	if got != want {
+		t.Fatalf("output mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+type dummyCloser struct {
+	closed bool
+}
+
+func (d *dummyCloser) Close() error {
+	d.closed = true
+	return nil
+}
+
+func TestSSEFilterBodyClose(t *testing.T) {
+	d := &dummyCloser{}
+	body := &sseFilterBody{
+		Reader: bytes.NewReader([]byte("test")),
+		closer: d,
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if !d.closed {
+		t.Fatal("expected closer to be closed")
+	}
+}
+


### PR DESCRIPTION
### 问题背景
在使用 OpenRouter 等第三方网关代理部分大模型（如 Gemini、排队推理模型）时，AI 对话插件经常偶发或必现报错：
`chat execution failed: LLM generation failed: unexpected end of JSON input`
### 根因分析
1. **网关行为**：OpenRouter 等网关在等待上游模型初始化或防超时挂起时，会在正式返回 `data:` 之前先下发一行心跳注释行，形如：
   ```sse
   : OPENROUTER PROCESSING\n\n
2. **SDK 缺陷**：github.com/openai/openai-go/v3 底层的 ssestream.Decoder 在解析到冒号开头的注释行时会忽略该行，但遇到紧随其后的 \n\n（连续换行）时，误判为一个事件结束，向外派发了一个 Data 为空的 Event。
3. **反序列化崩溃**：SDK 随后拿空字节去反序列化 json.Unmarshal([]byte{}, &chunk)，Go 标准库直接返回原生错误 unexpected end of JSON input，导致整条流提前断开报错。
### 修复方案
在底层 HTTP 传输层实现轻量级的 sseCommentFilterReader：

1. 拦截 Content-Type: text/event-stream 的响应流；
2. 过滤掉所有以 : 开头的注释行；
3. 丢弃未跟随在有效 data: 行之后的孤立空行，确保传递给 SDK 的只有合法的完整 SSE 事件块；
4. 通过官方预留的 option.WithHTTPClient 挂载，不侵入改动任何原有上层业务逻辑，保留系统代理支持（http.DefaultTransport）。

### 验证情况
 新增 sse_transport_test.go 单元测试，覆盖注释帧剥离、多行数据、孤立换行丢弃场景，全部通过。
 实测 OpenRouter 接口：未加过滤前 5 次调用全部必现报错，加入过滤后 5 次调用全部秒回且流式打字输出正常。
 运行全局测试 go test ./...，全部通过。